### PR TITLE
Improve formatting

### DIFF
--- a/src/tldr.cpp
+++ b/src/tldr.cpp
@@ -11,13 +11,13 @@
 #include <curl/curl.h>
 #include <sys/utsname.h>
 
-#define ANSI_COLOR_BLACK_BG     "\x1b[40m"
-#define ANSI_COLOR_RED          "\x1b[31m"
-#define ANSI_COLOR_GREEN        "\x1b[32m"
-#define ANSI_COLOR_WHITE        "\x1b[37m"
-#define ANSI_COLOR_RESET_ALL    "\x1b[0m"
-#define ANSI_COLOR_RESET_BG     "\x1b[49m"
-#define ANSI_COLOR_RESET_FG     "\x1b[39m"
+static const char * const ANSI_COLOR_RESET_FG            = "\x1b[39m";
+
+static const char * const ANSI_COLOR_EXPLANATION_FG      = ANSI_COLOR_RESET_FG;
+static const char * const ANSI_COLOR_COMMENT_FG          = "\x1b[32m";
+
+static const char * const ANSI_COLOR_CODE_FG             = "\x1b[31m";
+static const char * const ANSI_COLOR_CODE_PLACEHOLDER_FG = "\x1b[34m";
 
 
 int main(int argc, char *argv[])
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
         std::string response = getContentForUrl(urlForPlatform);
         if (response.empty()) response = getContentForUrl(url);
 
-        replaceAll(response, "{{", ANSI_COLOR_WHITE);
+        replaceAll(response, "{{", ANSI_COLOR_CODE_PLACEHOLDER_FG);
         replaceAll(response, "}}", ANSI_COLOR_RESET_FG);
 
         std::string const stripPrefix("#");
@@ -47,15 +47,18 @@ int main(int argc, char *argv[])
 
         while(std::getline(ss, to, '\n'))
         {
+            // Title
             if (to.compare(0, stripPrefix.size(), stripPrefix) == 0)
             {
                 // Do nothing!
             }
+            // Command explanation
             else if (to.compare(0, explainPrefix.size(), explainPrefix) == 0)
             {
-                replaceAll(to, ">", ANSI_COLOR_WHITE);
+                replaceAll(to, ">", ANSI_COLOR_EXPLANATION_FG);
                 std::cout << to << ANSI_COLOR_RESET_FG << std::endl;
             }
+            // Example comment
             else if (to.compare(0, commentPrefix.size(), commentPrefix) == 0)
             {
                 if (firstComment)
@@ -64,14 +67,22 @@ int main(int argc, char *argv[])
                     firstComment = false;
                 }
 
-                replaceAll(to, "-", ANSI_COLOR_GREEN);
+                replaceAll(to, "-", ANSI_COLOR_COMMENT_FG);
                 std::cout << to << ANSI_COLOR_RESET_FG << std::endl;
             }
+            // Code example
             else if (to.compare(0, codePrefix.size(), codePrefix) == 0)
             {
-                to = to.substr(1, to.size());
+                // Remove trailing backtick (`).
                 to = to.substr(0, to.size() - 1);
-                std::cout << ANSI_COLOR_BLACK_BG << to << ANSI_COLOR_RESET_BG << std::endl << std::endl;
+
+                // Replace first backtick (`) with three spaces for aligned indentation.
+                replaceAll(to, "`", "   ");
+                std::cout << ANSI_COLOR_CODE_FG
+                          << to
+                          << ANSI_COLOR_RESET_FG
+                          << std::endl
+                          << std::endl;
             }
         }
     }

--- a/src/tldr.cpp
+++ b/src/tldr.cpp
@@ -13,11 +13,15 @@
 
 static const char * const ANSI_COLOR_RESET_FG            = "\x1b[39m";
 
+static const char * const ANSI_COLOR_TITLE_FG            = ANSI_COLOR_RESET_FG;
 static const char * const ANSI_COLOR_EXPLANATION_FG      = ANSI_COLOR_RESET_FG;
 static const char * const ANSI_COLOR_COMMENT_FG          = "\x1b[32m";
 
 static const char * const ANSI_COLOR_CODE_FG             = "\x1b[31m";
 static const char * const ANSI_COLOR_CODE_PLACEHOLDER_FG = "\x1b[34m";
+
+static const char * const ANSI_BOLD_ON                   = "\x1b[1m";
+static const char * const ANSI_BOLD_OFF                  = "\x1b[22m";
 
 
 int main(int argc, char *argv[])
@@ -50,7 +54,13 @@ int main(int argc, char *argv[])
             // Title
             if (to.compare(0, stripPrefix.size(), stripPrefix) == 0)
             {
-                // Do nothing!
+                replaceAll(to, "#", ANSI_COLOR_TITLE_FG);
+                std::cout << std::endl
+                          << ANSI_BOLD_ON
+                          << to
+                          << ANSI_BOLD_OFF
+                          << ANSI_COLOR_RESET_FG
+                          << std::endl;
             }
             // Command explanation
             else if (to.compare(0, explainPrefix.size(), explainPrefix) == 0)

--- a/src/tldr.cpp
+++ b/src/tldr.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
         std::string const codePrefix("`");
         std::stringstream ss(response);
         std::string to;
-        int firstComment = 0;
+        bool firstComment = true;
 
         while(std::getline(ss, to, '\n'))
         {
@@ -58,10 +58,10 @@ int main(int argc, char *argv[])
             }
             else if (to.compare(0, commentPrefix.size(), commentPrefix) == 0)
             {
-                if (firstComment == 0)
+                if (firstComment)
                 {
                     std::cout << std::endl;
-                    firstComment = 1;
+                    firstComment = false;
                 }
 
                 replaceAll(to, "-", ANSI_COLOR_GREEN);


### PR DESCRIPTION
This PR aims to improve the formatting of the output so that it works with, more or less, any terminal theme. It should resolve the issues reported in tldr-pages/tldr#388. I’ve tested it with several different themes myself. See the attached screenshots.

It also makes the output be closer to that of the Node.js client, i.e. adding the title to the output. Very similar to the changes in tldr-pages/tldr-node-client#39.

----

### Before
#### Tomorrow Night theme
<img width="670" alt="screen shot 2015-12-30 at 14 05 55" src="https://cloud.githubusercontent.com/assets/23453/12055791/7ead48c4-aefe-11e5-8cb7-9da5b1500fcd.png">

#### Solarized Light
<img width="670" alt="screen shot 2015-12-30 at 14 11 48" src="https://cloud.githubusercontent.com/assets/23453/12055877/4d2ceace-aeff-11e5-8683-36590fcc7198.png">

#### Light theme (standard in iTerm 2)
<img width="670" alt="screen shot 2015-12-30 at 14 06 46" src="https://cloud.githubusercontent.com/assets/23453/12055813/a75d65e2-aefe-11e5-910a-d461dd3a9682.png">

----

### After
##### Tomorrow Night theme
<img width="670" alt="screen shot 2015-12-30 at 14 10 55" src="https://cloud.githubusercontent.com/assets/23453/12055867/323c4a34-aeff-11e5-92d7-90b1db6fe18b.png">

#### Solarized Light
<img width="670" alt="screen shot 2015-12-30 at 14 09 31" src="https://cloud.githubusercontent.com/assets/23453/12055847/0060f334-aeff-11e5-8863-8f95d844e5e7.png">

#### Light theme (standard in iTerm 2)
<img width="670" alt="screen shot 2015-12-30 at 14 07 59" src="https://cloud.githubusercontent.com/assets/23453/12055826/c7a33372-aefe-11e5-9f6a-cf6cfb7bf67d.png">