### PR TITLE
Add a blank line at the end of output

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -135,6 +135,7 @@ parse_tldrpage(char const *input)
         }
     }
 
+    fprintf(stdout, "\n");
     return 0;
 }
 


### PR DESCRIPTION
A blank line was added at the end of the output since there is a blank line before and after each item.
This closes #28 

Before
![2017-12-30 01 33 00](https://user-images.githubusercontent.com/23500659/34441808-772e2f8a-ed01-11e7-9593-20e62953c0dc.png)

After
![2017-12-30 01 32 34](https://user-images.githubusercontent.com/23500659/34441814-7c7ad16e-ed01-11e7-8eda-867ef824fd4a.png)