### PR TITLE
Assume yes for apt installation

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -20,7 +20,7 @@ elif [ "$UNAME" = "Linux" ]; then
 
     if [ "$HAS_APT" -eq 1 ]; then
         apt-get update
-        apt-get install libcurl4-openssl-dev libzip-dev pkg-config || exit 1
+        apt-get install -y libcurl4-openssl-dev libzip-dev pkg-config || exit 1
     elif [ "$HAS_PACMAN" -eq 1 ]; then
         pacman -Syy
         pacman -S libzip libcurl-gnutls pkg-config || exit 1


### PR DESCRIPTION


## What does it do?
Runs `apt-get` install with the `-y` option to automatically approve installing new packages.

## Why the change?
I'm trying to automate installing this package, but I can't run
deps.sh from a script very easily because I have to say yes to allow
apt to install new packages. I'm already running this as sudo, it
seems fair to say that I want to install these packages.


## How can this be tested?
Attempt to run this in a VM that uses `apt` where the necessary packages are not already installed. Note that the script runs completely without prompting the user to approve installation of new 

## Where to start code review?
Line 23 is the only line changed, I'd start there 😛 

## Relevant tickets?
None

## Questions?
Nope 😃 
