### PR TITLE
Specify cache directory with TLDR_CACHE_DIR

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -28,11 +28,16 @@ char const *
 gethome(void)
 {
     char const *homedir = NULL;
-    if ((homedir = getenv("HOME")) == NULL) {
-        struct passwd *uid;
-        if ((uid = getpwuid(getuid())) != NULL)
-            homedir = uid->pw_dir;
-    }
+    struct passwd *uid;
+
+    if ((homedir = getenv("TLDR_CACHE_DIR")) != NULL)
+        return homedir;
+
+    if ((homedir = getenv("HOME")) != NULL)
+        return homedir;
+
+    if ((uid = getpwuid(getuid())) != NULL)
+        homedir = uid->pw_dir;
 
     return homedir;
 }


### PR DESCRIPTION
## What does it do?
Currently the cache will always live in the home directory. This
allows the user to specify a directory to store the cache in with the
`TLDR_CACHE_DIR` environment variable. If the environment variable is
not set, the default will still be the home directory.


## Why the change?
Requested by #37 

Also it's been too long since I got to write any C

## How can this be tested?
* Compile the app with this patch
* Run `TLDR_CACHE_DIR=/some/path tldr man` and note that `/some/path/.tldrc` is populated with cache data
* Run `tldr man` without the `TLDR_CACHE_DIR` variable and note that `~/.tldrc` is populated with cache data

## Where to start code review?
The `gethome()` function in utils.c

## Relevant tickets?
#37 

## Questions?
Right now setting `TLDR_CACHE_DIR` to `/some/path` will result in populating a directory `/some/path/.tldrc`. Should this instead just put the cache data directly in `/some/path` and skip the "extra" directory?

Also is it worth computing the result of `gethome()` only once and caching it? I don't know if calls to `getenv()` are expensive.
