### PR TITLE
Add list feature

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <dirent.h>
 #include <sys/stat.h>
 
 int
@@ -206,6 +207,78 @@ print_tldrpage(char const *input, char const *poverride)
     parse_tldrpage(output);
 
     free(output);
+    return 0;
+}
+
+int
+print_tldrlist(char const *poverride)
+{
+    char const *platform;
+    char const *homedir;
+    size_t len;
+    char directory[STRBUFSIZ];
+
+    if (poverride == NULL) {
+        platform = getplatform();
+    } else {
+        platform = poverride;
+        if (strcmp(platform, "linux") != 0 && strcmp(platform, "osx") != 0 &&
+            strcmp(platform, "common") != 0 && strcmp(platform, "sunos") != 0) {
+            fprintf(stderr, "Error: platform %s is unsupported\n", platform);
+            fprintf(
+                stderr, "Supported platforms: linux / osx / sunos / common\n");
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    homedir = gethome();
+    if (homedir == NULL)
+        return 1;
+
+    len = 0;
+    if (sstrncat(directory, &len, STRBUFSIZ, homedir, strlen(homedir)))
+        return 1;
+    if (sstrncat(directory, &len, STRBUFSIZ, TLDR_EXT, TLDR_EXT_LEN))
+        return 1;
+
+    if (strcmp(platform, "common") != 0) {
+        parse_tldrlist(directory, platform);
+        fprintf(stdout, "\n");
+    }
+
+    parse_tldrlist(directory, "common");
+
+    return 0;
+}
+
+int
+parse_tldrlist(char const *path, char const *platform)
+{
+    struct dirent *entry;
+    DIR *directory;
+    char fullpath[STRBUFSIZ];
+    size_t len;
+
+    len = 0;
+    if (sstrncat(fullpath, &len, STRBUFSIZ, path, strlen(path)))
+        return 1;
+    if (sstrncat(fullpath, &len, STRBUFSIZ, platform, strlen(platform)))
+        return 1;
+
+    fprintf(stdout, "%s", ANSI_BOLD_ON);
+    fprintf(stdout, "Pages for %s\n", platform);
+    fprintf(stdout, "%s", ANSI_BOLD_OFF);
+
+    directory = opendir(fullpath);
+
+    while((entry = readdir(directory))) {
+        len = strlen(entry->d_name);
+        if (strcmp(entry->d_name + (len - 3), ".md") != 0)
+            continue;
+
+        fprintf(stdout, "%.*s\n", (int) len - 3, entry->d_name);
+    }
+
     return 0;
 }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -11,7 +11,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <sys/utsname.h>
 
 int
 construct_url(char *buf, size_t buflen, char const *input, char const *platform)
@@ -141,32 +140,16 @@ parse_tldrpage(char const *input)
 int
 print_tldrpage(char const *input, char const *poverride)
 {
-    int islinux;
-    int isdarwin;
-    int issun;
     char *output;
     char url[URLBUFSIZ];
-    struct utsname sys;
     char const *platform;
     char const *homedir;
     size_t len;
     char directory[STRBUFSIZ];
     struct stat sb;
 
-    uname(&sys);
-    islinux = strcmp(sys.sysname, "Linux") == 0;
-    isdarwin = strcmp(sys.sysname, "Darwin") == 0;
-    issun = strcmp(sys.sysname, "SunOS") == 0;
-
     if (poverride == NULL) {
-        if (islinux)
-            platform = "linux";
-        else if (isdarwin)
-            platform = "osx";
-        else if (issun)
-            platform = "sunos";
-        else
-            platform = "common";
+        platform = getplatform();
     } else {
         platform = poverride;
         if (strcmp(platform, "linux") != 0 && strcmp(platform, "osx") != 0 &&

--- a/src/tldr.c
+++ b/src/tldr.c
@@ -31,6 +31,7 @@ static int verbose_flag;
 static int update_flag;
 static int clear_flag;
 static int platform_flag;
+static int list_flag;
 static int render_flag;
 static char pbuf[STRBUFSIZ];
 static struct option long_options[] = {
@@ -41,6 +42,7 @@ static struct option long_options[] = {
     { "update", no_argument, &update_flag, 1 },
     { "clear-cache", no_argument, &clear_flag, 1 },
     { "platform", required_argument, 0, 'p' },
+    { "list", no_argument, &list_flag, 'l'},
     { "render", required_argument, 0, 'r'}, {0, 0, 0, 0 }
 };
 
@@ -108,7 +110,7 @@ main(int argc, char **argv)
     }
 
     /* show help, if platform was supplied, but no further argument */
-    missing_arg = (platform_flag && (optind == argc));
+    missing_arg = (platform_flag && !list_flag && (optind == argc));
     if (help_flag || missing_arg) {
         print_usage(argv[0]);
         return EXIT_SUCCESS;
@@ -129,6 +131,14 @@ main(int argc, char **argv)
     }
     if (verbose_flag && optind >= argc) {
         print_version(argv[0]);
+        return EXIT_SUCCESS;
+    }
+    if (list_flag) {
+        if (!has_localdb())
+            update_localdb(verbose_flag);
+
+        if (print_tldrlist(pbuf[0] != 0 ? pbuf : NULL))
+            return EXIT_FAILURE;
         return EXIT_SUCCESS;
     }
     if (render_flag) {
@@ -193,6 +203,7 @@ print_usage(char const *arg)
     fprintf(stdout, "    %-20s %-30s\n", "-h, --help", "print this help and exit");
     fprintf(stdout, "    %-20s %-30s\n", "-u, --update", "update local database");
     fprintf(stdout, "    %-20s %-30s\n", "-c, --clear-cache", "clear local database");
+    fprintf(stdout, "    %-20s %-30s\n", "-l, --list", "list all entries in the local databse");
     fprintf(stdout, "    %-20s %-30s\n", "-p, --platform=PLATFORM",
             "select platform, supported are linux / osx / sunos / common");
     fprintf(stdout, "    %-20s %-30s\n", "-r, --render=PATH",

--- a/src/tldr.h
+++ b/src/tldr.h
@@ -68,6 +68,8 @@ int         construct_path          (char *buf, size_t buflen, char const *home,
                                      char const *input, char const *platform);
 int         parse_tldrpage          (char const *input);
 int         print_tldrpage          (char const *input, char const *platform);
+int         print_tldrlist          (char const *platform);
+int         parse_tldrlist          (char const *path, char const *platform);
 int         print_localpage         (char const *path);
 
 /* utils.c */

--- a/src/tldr.h
+++ b/src/tldr.h
@@ -77,6 +77,7 @@ double      rround              (double arg);
 int         rm                  (char const *path, int options);
 int         unzip               (char const *path, char const *outpath);
 char const *gethome             (void);
+char const *getplatform         (void);
 int         sstrncat            (char *dest, size_t *pos, size_t max,
                                  char const *src, size_t len);
 #endif /* TLDR_H */

--- a/src/utils.c
+++ b/src/utils.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/utsname.h>
 #include <unistd.h>
 #include <zip.h>
 
@@ -35,6 +36,22 @@ gethome(void)
     }
 
     return homedir;
+}
+
+char const *
+getplatform(void)
+{
+    struct utsname sys;
+    uname(&sys);
+
+    if (strcmp(sys.sysname, "Linux") == 0)
+        return "linux";
+    else if (strcmp(sys.sysname, "Darwin") == 0)
+        return "osx";
+    else if (strcmp(sys.sysname, "SunOS") == 0)
+        return "sunos";
+    else
+        return "common";
 }
 
 int


### PR DESCRIPTION
## What does it do?
Add `--list` option

This will list each of the commands for which there is an entry in the
current local database. It lists only packages for the current
platform or can be overwritten by the `--platform flag`. It will update
the local database if there is not one.

## Why the change?
Requested in #22 and #36 

## How can this be tested?
Compile the new version of and run `tldr --list`. It should list everything installed locally.

## Where to start code review?
The `print_tldrlist` and `parse_tldrlist` functions in `parser.c` contain the meat of the implementation.

## Relevant tickets?
* #22 
* #36 

## Questions?
* Does this output format make sense? I have an example of what it looks like [here](https://gist.github.com/packrat386/7de55064023a8a3004ce260fb28711b4)
* The code for ensuring that a provided platform flag is a supported platform is currently copied between `print_tldrlist` and `print_tldrpage`. My thought was that it might be best to refactor this into a separate check that we run when we parse flags. Is this a change you'd like to see? And if so, should I make that here or in a separate PR?
* I tried to copy the pattern of the existing `print_tldrpage` and `parse_tldrpage`. Does it make sense to use that same naming scheme? Should this perhaps go in a different file?

